### PR TITLE
Fix publisher API config

### DIFF
--- a/lib/config/api.yml
+++ b/lib/config/api.yml
@@ -422,7 +422,7 @@
   :power_listings:
     :module_name: Powerlistings
     :objects:
-      :publishser:
+      :publisher:
         :actions:
           - :action: :index
             :method: :get


### PR DESCRIPTION
Fixes typo in the publisher endpoint defined in the API config.